### PR TITLE
[Add, Update] StateProvider, 그 외 자식 컴포넌트들

### DIFF
--- a/todolist/src/App.css
+++ b/todolist/src/App.css
@@ -59,3 +59,8 @@ input {
   background: #86c6ff;
   color: rgba(255, 255, 255, 0.4);
 }
+
+.logStorage.appear {
+  right: 0px;
+  transition: all 0.5s;
+}

--- a/todolist/src/App.jsx
+++ b/todolist/src/App.jsx
@@ -1,7 +1,8 @@
 import "./App.css";
 import { createGlobalStyle } from "styled-components";
-import NavBar from "./components/navBar/NavBar";
-import { Column } from "./components/card/CardList.jsx";
+// import NavBar from "./components/navBar/NavBar";
+// import { Column } from "./components/card/CardList.jsx";
+import StateProvider from "./components/StateProvider";
 const GlobalStyle = createGlobalStyle`
   body{
     background: #e9ecef;
@@ -11,12 +12,13 @@ const GlobalStyle = createGlobalStyle`
     font-style: normal;
   }
 `;
+
 function App() {
   return (
     <>
       <GlobalStyle />
-      <NavBar />
-      <Column />
+      {/* <NavBar /> */}
+      <StateProvider />
     </>
   );
 }

--- a/todolist/src/components/StateProvider.jsx
+++ b/todolist/src/components/StateProvider.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import NavBar from "./navBar/NavBar";
+import { Column } from "./card/CardList";
+
+function StateProvider(props) {
+  const [log, setLog] = useState([
+    {
+      cardTitle: "HTML/CSS 공부하기",
+      columnTitle: "하고 있는 일",
+      modeType: "add",
+    },
+  ]);
+
+  const handleLog = ({ cardTitle, columnTitle, modeType }) => {
+    setLog(
+      log.concat({
+        cardTitle,
+        columnTitle,
+        modeType,
+      })
+    );
+  };
+
+  return (
+    <>
+      <NavBar log={log} />
+      <Column onLog={handleLog} />
+    </>
+  );
+}
+
+export default StateProvider;

--- a/todolist/src/components/card/Card.jsx
+++ b/todolist/src/components/card/Card.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 import styled from "styled-components";
-import { HiX } from "react-icons/hi";
+// import { HiX } from "react-icons/hi";
 import IconButton from "../utils/IconButton";
+
 const CardTitle = styled.div`
   font-weight: bold;
   font-size: 16px;
@@ -25,12 +26,8 @@ function Card(props) {
     <div className="card">
       <CardTitle className="card-title">{card.title}</CardTitle>
       <CardContent className="card-content">{card.content}</CardContent>
-      <IconButton
-        className="button-delete"
-        type="delete"
-        cb={() => onDelete(card)}
-      ></IconButton>
-      <HiX className="button-delete" onClick={() => onDelete(card)}></HiX>
+      <IconButton type="delete" cb={() => onDelete(card)}></IconButton>
+      {/* <HiX className="button-delete" onClick={() => onDelete(card)}></HiX> */}
     </div>
   );
 }

--- a/todolist/src/components/card/CardForm.jsx
+++ b/todolist/src/components/card/CardForm.jsx
@@ -13,8 +13,20 @@ function CardForm(props) {
   return (
     <form action="">
       <div className="card-input-section">
-        <input className="card-input-title" type="text" placeholder="title" value={title} onChange={(e) => setTitle(e.target.value)} />
-        <textarea cols="30" rows="10" placeholder="content" onChange={(e) => setContent(e.target.value)} defaultValue={content}></textarea>
+        <input
+          className="card-input-title"
+          type="text"
+          placeholder="title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <textarea
+          cols="30"
+          rows="10"
+          placeholder="content"
+          onChange={(e) => setContent(e.target.value)}
+          defaultValue={content}
+        ></textarea>
       </div>
       <div className="card-btn-section">
         <button className="btn cancel-btn" onClick={props.onCancel}>

--- a/todolist/src/components/card/CardList.jsx
+++ b/todolist/src/components/card/CardList.jsx
@@ -61,21 +61,32 @@ function Column(props) {
       content: "임시 내용",
     },
   ]);
+  const { onLog } = props;
 
-  const [enroll, setEnroll] = useState(false);
+  const [enrollMode, setEnrollMode] = useState(false);
 
   const handleCreate = (card) => {
-    setEnroll(!enroll);
+    setEnrollMode(!enrollMode);
     setCards(cards.concat(card));
+    onLog({
+      cardTitle: card.title,
+      columnTitle: "하고 있는 일",
+      modeType: "add",
+    });
   };
 
   const handleCancel = (e) => {
     e.preventDefault();
-    setEnroll(!enroll);
+    setEnrollMode(!enrollMode);
   };
 
   const handleDelete = (target) => {
     setCards(cards.filter((e) => e.id !== target.id));
+    onLog({
+      cardTitle: target.title,
+      columnTitle: "하고 있는 일",
+      modeType: "delete",
+    });
   };
 
   const handleUpdate = ({ id, title, content }) => {
@@ -83,6 +94,11 @@ function Column(props) {
     card.title = title;
     card.content = content;
     setCards(cards);
+    onLog({
+      cardTitle: title,
+      columnTitle: "하고 있는 일",
+      modeType: "update",
+    });
   };
 
   return (
@@ -90,9 +106,9 @@ function Column(props) {
       <header>
         <ColumnTitle>해야할 일</ColumnTitle>
         <ColumnCount>{cards.length}</ColumnCount>
-        <HiOutlinePlusSm onClick={() => setEnroll(!enroll)}></HiOutlinePlusSm>
+        <HiOutlinePlusSm onClick={() => setEnrollMode(!enrollMode)}></HiOutlinePlusSm>
       </header>
-      {enroll ? <CardForm onSubmit={handleCreate} onCancel={handleCancel} /> : ""}
+      {enrollMode ? <CardForm onSubmit={handleCreate} onCancel={handleCancel} onLog={onLog} /> : ""}
       <CardList cards={cards} onDelete={handleDelete} onUpdate={handleUpdate} />
     </ColumnContainer>
   );

--- a/todolist/src/components/card/CardWrap.jsx
+++ b/todolist/src/components/card/CardWrap.jsx
@@ -13,19 +13,27 @@ const CardContiner = styled.li`
 
 function CardWrap(props) {
   const { card, onDelete, onUpdate } = props;
-  const [edit, setEdit] = useState(false);
+  const [editMode, setEditMode] = useState(false);
 
   const handleSubmit = ({ id, title, content }) => {
     onUpdate({ id, title, content });
-    setEdit(!edit);
+    setEditMode(!editMode);
   };
 
   const handleEdit = (e) => {
     e.preventDefault();
-    setEdit(!edit);
+    setEditMode(!editMode);
   };
 
-  return <CardContiner onDoubleClick={handleEdit}>{edit ? <CardForm card={card} onSubmit={handleSubmit} onCancel={handleEdit} /> : <Card card={card} onDelete={onDelete} />}</CardContiner>;
+  return (
+    <CardContiner onDoubleClick={handleEdit}>
+      {editMode ? (
+        <CardForm card={card} onSubmit={handleSubmit} onCancel={handleEdit} />
+      ) : (
+        <Card card={card} onDelete={onDelete} />
+      )}
+    </CardContiner>
+  );
 }
 
 export default CardWrap;

--- a/todolist/src/components/navBar/LogStorage.jsx
+++ b/todolist/src/components/navBar/LogStorage.jsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
-import IconButton from "../utils/IconButton";
+// import IconButton from "../utils/IconButton";
 import LogCommit from "./LogCommit";
+import { HiX } from "react-icons/hi";
 
 const LogStorageBlock = styled.div`
   position: absolute;
@@ -9,47 +10,39 @@ const LogStorageBlock = styled.div`
   right: -440px;
   top: 0px;
   background: #ffffff;
-  box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
-    0px 2px 4px rgba(0, 0, 0, 0.25);
+  box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5), 0px 2px 4px rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(4px);
 `;
 
-const LogBlock = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  padding: 16px;
-
-  position: static;
-  width: 332px;
-  height: 137px;
-  left: 0px;
-  top: 0px;
-
-  background: #ffffff;
-
-  flex: none;
-  order: 0;
-  flex-grow: 0;
-  margin: auto auto;
+const IconX = styled.div`
+  display: block;
+  position: absolute;
+  right: 80px;
+  top: 50px;
 `;
 
 const LogList = styled.div`
   margin-top: 80px;
 `;
 
-function LogStorage({ LogStorageDom }) {
+function LogStorage({ LogStorageDom, setLogViewState }) {
+  const handleXbtnClick = (LogStorageDom) => {
+    setLogViewState(false);
+    LogStorageDom.currentTarget.classList.remove("appear");
+  };
+
   return (
     <>
       <LogStorageBlock className="logStorage appear" ref={LogStorageDom}>
-        <IconButton type="delete"></IconButton>
+        {/* <IconButton type="delete"></IconButton> */}
+        <IconX onClick={handleXbtnClick}>
+          <HiX></HiX>
+        </IconX>
         <LogList>
           <LogCommit></LogCommit>
         </LogList>
       </LogStorageBlock>
-      ;
     </>
   );
 }
-
 export default LogStorage;

--- a/todolist/src/components/navBar/NavBar.jsx
+++ b/todolist/src/components/navBar/NavBar.jsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import { HiMenu } from "react-icons/hi";
 import { useState, useRef } from "react";
 import LogStorage from "./LogStorage";
+// import IconButton from "../utils/IconButton";
 
 const NavBlock = styled.div`
   width: 1440px;
@@ -17,18 +18,13 @@ const TitleBlock = styled.div`
   height: 46px;
   left: 80px;
   top: 33px;
-
   font-family: Noto Sans KR;
   font-style: normal;
   font-weight: normal;
   font-size: 32px;
   line-height: 46px;
-
-  /* Black */
-
   color: #010101;
 `;
-
 const LogBtnBlock = styled.div`
   width: 34px;
   height: 22px;
@@ -37,24 +33,26 @@ const LogBtnBlock = styled.div`
   top: 40px;
 `;
 
-function NavBar() {
+function NavBar(props) {
+  const { log } = props;
+  console.log(log);
+  // 잘 찍히는거 확인
   const LogStorageDom = useRef();
   const [appear, setLogViewState] = useState(false);
-
-  const handleLogBtnClick = () => {
-    setLogViewState(true); //바로 값이 바뀌지는 않는다.
-    // if (appear) LogStorageDom.current.classList.add("appear");
+  const handleLogBtnClick = (LogStorageDom) => {
+    setLogViewState(true);
+    if (appear) LogStorageDom.current.classList.add("appear");
   };
-
   return (
     <>
       <NavBlock>
         <TitleBlock>TO-DO LIST</TitleBlock>
         <LogBtnBlock>
+          {/* <IconButton type="menu" cb={handleLogBtnClick} size="60" /> */}
           <HiMenu className="icon" onClick={handleLogBtnClick} />
         </LogBtnBlock>
       </NavBlock>
-      {appear && <LogStorage logDom={LogStorageDom}></LogStorage>}
+      {appear && <LogStorage ref={LogStorageDom} setLogViewState={setLogViewState}></LogStorage>}
     </>
   );
 }

--- a/todolist/src/components/utils/IconButton.jsx
+++ b/todolist/src/components/utils/IconButton.jsx
@@ -21,6 +21,7 @@ const StyledButton = styled.button`
       `;
   }}
 `;
+
 export default function IconButton({ cb, type, size }) {
   return (
     <StyledButton size={size} onClick={cb}>

--- a/todolist/src/components/utils/constant.js
+++ b/todolist/src/components/utils/constant.js
@@ -1,7 +1,8 @@
-import { MdMenu, MdDelete, MdAdd } from "react-icons/md";
+import { MdMenu, MdAdd } from "react-icons/md";
+import { HiX } from "react-icons/hi";
 
 export const BUTTON_TYPE = {
   add: <MdAdd />,
-  delete: <MdDelete />,
+  delete: <HiX />,
   menu: <MdMenu />,
 };


### PR DESCRIPTION
- App의 자식으로 StateProvider 생성
    - 카드의 등록,수정,삭제 여부에 따른 state관리용
    - NavBar에 전달하기위함
- StateProvider의 props를 내려주는 테스트 수행
    - onLog로 내려줌
    - 확인
- NavBar 추가작업 취합